### PR TITLE
Patch CACTUS AMC13 Makefiles to work on Debian/Ubuntu

### DIFF
--- a/cmake/External_cactus.cmake
+++ b/cmake/External_cactus.cmake
@@ -28,6 +28,7 @@ ExternalProject_Add(cactus-amc13
   PATCH_COMMAND patch -p1 -i "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/amc13-cpp11.patch"
   COMMAND       patch -p1 -i "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/amc13-python3.patch"
   COMMAND       patch -p1 -i "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/amc13-install.patch"
+  COMMAND       patch -p1 -i "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/amc13-as-needed.patch"
 
   CONFIGURE_COMMAND ""
   BUILD_IN_SOURCE TRUE

--- a/cmake/External_cactus.cmake
+++ b/cmake/External_cactus.cmake
@@ -35,6 +35,7 @@ ExternalProject_Add(cactus-amc13
   BUILD_COMMAND make
     "CACTUS_ROOT=${CMAKE_BINARY_DIR}/install/cactus"
     "INSTALL_PREFIX=<INSTALL_DIR>"
+    "SHELL=bash"
   INSTALL_COMMAND make install
     "CACTUS_ROOT=${CMAKE_BINARY_DIR}/install/cactus"
     "INSTALL_PREFIX=<INSTALL_DIR>"

--- a/cmake/External_xdaq.cmake
+++ b/cmake/External_xdaq.cmake
@@ -8,6 +8,7 @@ ExternalProject_Add(xdaq-core
 
   PATCH_COMMAND patch -p1 -i "${CMAKE_SOURCE_DIR}/thirdparty/xalan-makefile.patch"
   COMMAND       patch -p1 -i "${CMAKE_SOURCE_DIR}/thirdparty/xdaq-core-cpp11.patch"
+  COMMAND       patch -p1 -i "${CMAKE_SOURCE_DIR}/thirdparty/xdaq-core-asyncresolv.patch"
 
   CONFIGURE_COMMAND ""
   BUILD_IN_SOURCE TRUE

--- a/thirdparty/amc13-as-needed.patch
+++ b/thirdparty/amc13-as-needed.patch
@@ -1,0 +1,51 @@
+diff -ur a/amc13/Makefile b/amc13/Makefile
+--- a/amc13/Makefile
++++ b/amc13/Makefile
+@@ -35,13 +35,13 @@
+ 	-L$(CACTUS_ROOT)/lib 
+ 
+ LIBRARIES =     -lpthread 			\
++                -lcactus_uhal_log 		\
++                -lcactus_uhal_grammars 		\
++                -lcactus_uhal_uhal		\
+                 -lboost_filesystem 		\
+                 -lboost_regex 			\
+                 -lboost_system 			\
+-                -lboost_thread 			\
+-                -lcactus_uhal_log 		\
+-                -lcactus_uhal_grammars 		\
+-                -lcactus_uhal_uhal
++                -lboost_thread
+ 
+ 
+ CPP_FLAGS = -g -O3 -rdynamic -Wall -MMD -MP -fPIC ${INCLUDE_PATH} -fno-strict-aliasing
+@@ -74,7 +74,7 @@
+ 	@svn -R info | awk 'BEGIN{version=0}{if($$3 == "Rev:"){if($$4 > version){version = $$4}}}END{print "const int amc13::AMC13::Version(" version ");"}' >> ${VERSION_SRC}
+ 	@g++ ${CPP_FLAGS} -c ${VERSION_SRC} -o ${VERSION_OBJ} ; rm ${VERSION_SRC} 
+ 	@#build the actual library
+-	g++ ${LINK_FLAGS} ${OBJECT_FILES} ${OBJECT_FILES_UNPACKER} ${VERSION_OBJ} -o $@ 
++	g++ ${OBJECT_FILES} ${OBJECT_FILES_UNPACKER} ${VERSION_OBJ} ${LINK_FLAGS} -o $@ 
+ 	@#remove any trace of the version file
+ 	@rm ${VERSION_OBJ}
+ 
+diff -ur a/tools/Makefile b/tools/Makefile
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -79,7 +79,7 @@
+ # Executables
+ # ------------------------
+ ${EXECUTABLES}: bin/%.exe: obj/%.o ${EXECUTABLE_OBJECT_FILES}
+-	g++ ${LINK_EXECUTABLE_FLAGS} $< -o $@
++	g++ $< ${LINK_EXECUTABLE_FLAGS} -o $@
+ 
+ ${EXECUTABLE_OBJECT_FILES}: obj/%.o : src/common/%.cxx
+ 	mkdir -p {bin,obj,lib}
+@@ -91,7 +91,7 @@
+ # library
+ # ------------------------
+ ${LIBRARY}: ${LIBRARY_OBJECT_FILES}
+-	g++ ${LINK_LIBRARY_FLAGS} ${LIBRARY_OBJECT_FILES} -o $@
++	g++ ${LIBRARY_OBJECT_FILES} ${LINK_LIBRARY_FLAGS} -o $@
+ 
+ ${LIBRARY_OBJECT_FILES}: obj/%.o : src/common/%.cc 
+ 	mkdir -p {lib,obj}

--- a/thirdparty/xdaq-core-asyncresolv.patch
+++ b/thirdparty/xdaq-core-asyncresolv.patch
@@ -1,0 +1,27 @@
+diff -urN a/asyncresolv/disable-werror.patch b/extern/asyncresolv/disable-werror.patch
+--- a/extern/asyncresolv/disable-werror.patch
++++ b/extern/asyncresolv/disable-werror.patch
+@@ -0,0 +1,11 @@
++--- asyncresolv-0.0.4/configure.in
+++++ asyncresolv-0.0.4/configure.in
++@@ -70,7 +70,7 @@
++ # Compiling options
++ CXXFLAGS="${CXXFLAGS} -pipe"
++ # Warning options 
++-CXXFLAGS="${CXXFLAGS} -Werror -Wall -Winline"
+++CXXFLAGS="${CXXFLAGS} -Wall -Winline"
++ # 
++ CXXFLAGS="${CXXFLAGS} -D_REENTRANT -D_THREAD_SAFE"
++ 
+diff -urN a/extern/asyncresolv/Makefile b/extern/asyncresolv/Makefile
+--- a/extern/asyncresolv/Makefile
++++ b/extern/asyncresolv/Makefile
+@@ -61,7 +61,7 @@
+ LD:=$(LDD)
+ export LD
+ 
+-PATCH=patch -p0 < asyncresolv-0.0.4.patch; patch -p0 < sf1672525.patch; patch -p0 < cmsos550.patch; patch -p0 < cmsos698.patch
++PATCH=patch -p0 < asyncresolv-0.0.4.patch; patch -p0 < sf1672525.patch; patch -p0 < cmsos550.patch; patch -p0 < cmsos698.patch; patch -p0 < disable-werror.patch
+ 
+ build: _buildall
+ 


### PR DESCRIPTION
The --as-needed linker flag (enabled by default on Ubuntu 18.04) breaks
compilation. Fix it by reordering -l flags.

Tested by doing the following:

```sh
$ rm -r thirdparty/cactus/amc13/
$ XDAQ_PLATFORM=x86_64 XDAQ_ROOT=$(readlink -f install/xdaq/x86_64/) make
```

Compilation succeeds.